### PR TITLE
Update testssl wrapper to support fallback

### DIFF
--- a/server_api/web_probe/testssl.py
+++ b/server_api/web_probe/testssl.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, request, jsonify
 import logging
 import shlex
+import shutil
 from server_core.command_executor import execute_command
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,13 @@ def testssl():
         if not isinstance(openssl_timeout, int) or openssl_timeout < 0:
             return jsonify({"error": "openssl_timeout must be a non-negative integer"}), 400
 
-        args = ["testssl.sh"]
+        testssl_executable = shutil.which('testssl') or shutil.which('testssl.sh')
+        if not testssl_executable:
+            logger.error("Neither 'testssl' nor 'testssl.sh' found on system PATH.")
+            return jsonify({"error": "testssl tool not found"}), 400
+
+        # Prepare argument list with the appropriate executable
+        args = [testssl_executable]
 
         if help_mode:
             args.append("--help")


### PR DESCRIPTION


## Description
There are two methods to install testssl. One is to install by cloning the github repo. The second is to install via linux package. The clone will have a testssl.sh file in the cloned directory. The package will create a /usr/bin/testssl file.

To accomodate both environments this change looks for both on the path in the environment that hexstrike runs within.

- Modified the testssl wrapper to check for the 'testssl' command first.
- Added fallback to 'testssl.sh' if 'testssl' is not found.
- Enhanced error handling to provide clear messaging when neither executable is available.

---

## Type of change

- [ x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Formatting / linting only

---

## Scope rules

✅ This PR only modifies files relevant to the change  
✅ This PR does NOT include unrelated formatting changes  
✅ Large formatting changes are submitted in a separate PR  

---

## AI Usage Disclosure

If AI tools were used while creating this PR:

- [ ] No AI used
- [ x] AI assisted, but all code was reviewed and verified by the author

> Note: PRs containing unreviewed or bulk AI-generated changes may be rejected.

---

## Testing

- [ x] I have tested my changes

---